### PR TITLE
Fix pillar example: use default redis port

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -1,7 +1,7 @@
 redis:
   root_dir: /var/lib/redis
   user: redis
-  port: 6397
+  port: 6379
   bind: 127.0.0.1
   snapshots:
     - '900 1'


### PR DESCRIPTION
According to redis docs, 6379 is the default port.

http://redis.io/topics/quickstart